### PR TITLE
Improved threading

### DIFF
--- a/aws_list_resources.py
+++ b/aws_list_resources.py
@@ -176,8 +176,8 @@ if __name__ == "__main__":
                 # Submit a task to the executor for each resource type
                 futures.append(executor.submit(analyze_resource, boto_session, region, resource_type, result_collection, only_show_counts))
     
-        # Wait for all tasks to complete
-        concurrent.futures.wait(futures)
+    # Wait for all tasks to complete
+    concurrent.futures.wait(futures)
 
     # Write result file
     result_file = os.path.join(


### PR DESCRIPTION
I think that threading per region is rather conservative, and could be improved upon (especially if there is a small amount of regions being parsed) by threading at the list-resources API level instead of per region.

This PR request implements this change